### PR TITLE
Fix urllib3 streaming with highly compressed data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-certifi==2019.11.28
-chardet==3.0.4
+certifi==2024.8.30
+chardet==5.2.0
 crossref-commons==0.0.7
-idna==2.9
+idna==3.10
 ratelimit==2.2.1
-requests==2.23.0
-urllib3==1.25.8
+requests==2.32.3
+urllib3==2.6.0


### PR DESCRIPTION
Updated urllib3 from 1.25.8 to 2.6.0 to address CVE-2025-66471, a high-severity vulnerability (CVSS 8.9) in urllib3's streaming API. The vulnerability allows decompression bomb attacks that can cause excessive CPU and memory consumption.

Also updated related dependencies for compatibility and security:
- requests: 2.23.0 → 2.32.3
- certifi: 2019.11.28 → 2024.8.30
- chardet: 3.0.4 → 5.2.0
- idna: 2.9 → 3.10